### PR TITLE
Route を LoginPage に適用忘れ

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -4,6 +4,7 @@ import 'package:gottiesclient/models/stores/post_page_store.dart';
 import 'package:gottiesclient/models/stores/stores.dart';
 import 'package:gottiesclient/pages/detail/detail_page.dart';
 import 'package:gottiesclient/pages/home/home_page.dart';
+import 'package:gottiesclient/pages/login/login_page.dart';
 import 'package:gottiesclient/pages/post/post_page.dart';
 import 'package:provider/provider.dart';
 
@@ -48,13 +49,31 @@ class MyApp extends StatelessWidget {
                 primarySwatch: Colors.red,
                 fontFamily: 'NotoSansJP-Regular',
               ),
-              routes: <String, WidgetBuilder>{
-                '/': (BuildContext context) => HomePage(),
-                '/detail': (BuildContext context) {
-                  final article = ModalRoute.of(context).settings.arguments as Article;
-                  return DetailPage(article: article);
-                },
-                '/post': (BuildContext context) => PostPage()
+              onGenerateRoute: (RouteSettings settings) {
+                switch (settings.name) {
+                  case '/':
+                    return MaterialPageRoute<void>(
+                      builder: (_) => HomePage(),
+                    );
+                  case '/detail':
+                    return MaterialPageRoute<void>(
+                      builder: (BuildContext context) {
+                        final article = ModalRoute.of(context).settings.arguments as Article;
+                        return DetailPage(article: article);
+                      },
+                    );
+                  case '/post':
+                    return MaterialPageRoute<void>(
+                      builder: (_) => PostPage(),
+                    );
+                  case '/login':
+                    return MaterialPageRoute<void>(
+                      builder: (_) => LoginPage(),
+                      fullscreenDialog: true,
+                    );
+                  default:
+                    throw UnimplementedError('Undefined route ${settings.name}');
+                }
               },
             ),
           );

--- a/lib/widgets/my_appbar.dart
+++ b/lib/widgets/my_appbar.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:gottiesclient/models/stores/stores.dart';
-import 'package:gottiesclient/pages/login/login_page.dart';
 import 'package:gottiesclient/util/typedefs.dart';
 import 'package:gottiesclient/widgets/search_text_field.dart';
 import 'package:provider/provider.dart';
@@ -42,13 +41,7 @@ class MyAppBar extends StatelessWidget implements PreferredSizeWidget {
               ),
             ),
             onPressed: () {
-              Navigator.push<void>(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => LoginPage(),
-                  fullscreenDialog: true,
-                ),
-              );
+              Navigator.pushNamed(context, '/login');
             },
           ),
         )


### PR DESCRIPTION
## やったこと
- LoginPage に `pushNamed` で遷移できるように変更
- `fullscreenDialog` を指定するために `Route` の生成から行う必要があったため、`routes` の代わりに `onGenerateRoute` を使った。 

## スクリーンショット
Before|After
--|--
<img src="" width="300px">|<img src="" width="300px">
