### PR TITLE
rename repository to client

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -16,19 +16,19 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(
           create: (_) => LoginStore(),
         ),
-        Provider<BaseRepository>.value(
-          value: FirestoreRepository(),
+        Provider<BaseClient>.value(
+          value: FirestoreClient(),
         ),
       ],
-      child: Consumer2<LoginStore, BaseRepository>(
-        builder: (_, loginStore, repository, ___) {
+      child: Consumer2<LoginStore, BaseClient>(
+        builder: (_, loginStore, client, ___) {
           return MultiProvider(
             providers: [
               ChangeNotifierProvider(
-                create: (_) => ArticleStore(loginStore, repository),
+                create: (_) => ArticleStore(loginStore, client),
               ),
               ChangeNotifierProvider(
-                create: (_) => CategoryStore(repository),
+                create: (_) => CategoryStore(client),
               ),
               ChangeNotifierProvider(
                 create: (_) => PostPageStore(),

--- a/lib/models/api_repository.dart
+++ b/lib/models/api_repository.dart
@@ -5,11 +5,11 @@ import 'package:flutter/cupertino.dart';
 import 'package:gottiesclient/models/models.dart';
 import 'package:http/http.dart' as http;
 
-class ApiRepository implements BaseRepository {
+class ApiClient implements BaseClient {
   // TODO: APIの仕様が決まれば追記
   final String _baseUrl = 'http://localhost:8080';
 
-  final FirestoreRepository _firestoreRepository = FirestoreRepository();
+  final FirestoreClient _firestoreRepository = FirestoreClient();
 
   @override
   Future<List<Article>> getArticles() async {

--- a/lib/models/base_repository.dart
+++ b/lib/models/base_repository.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:gottiesclient/models/entities/entities.dart';
 
-abstract class BaseRepository {
+abstract class BaseClient {
   Future<List<Article>> getArticles();
   Future<void> postArticle(String title, File before, File after, String body, String categoryId, String userId);
   Future<void> deleteArticle(String id, String userID);

--- a/lib/models/firestore_repository.dart
+++ b/lib/models/firestore_repository.dart
@@ -6,7 +6,7 @@ import 'package:firebase_storage/firebase_storage.dart';
 import 'package:gottiesclient/models/models.dart';
 import 'package:uuid/uuid.dart';
 
-class FirestoreRepository implements BaseRepository {
+class FirestoreClient implements BaseClient {
   final Firestore _firestore = Firestore.instance;
   final Uuid _uuid = Uuid();
 

--- a/lib/models/stores/article_store.dart
+++ b/lib/models/stores/article_store.dart
@@ -6,15 +6,15 @@ import 'package:gottiesclient/models/models.dart';
 import 'package:gottiesclient/models/stores/stores.dart';
 
 class ArticleStore extends ChangeNotifier {
-  ArticleStore(LoginStore loginStore, BaseRepository repository)
-      : assert(repository != null),
+  ArticleStore(LoginStore loginStore, BaseClient client)
+      : assert(client != null),
         assert(loginStore != null),
         _loginStore = loginStore,
-        _repository = repository {
+        _client = client {
     getArticles();
   }
 
-  final BaseRepository _repository;
+  final BaseClient _client;
   final LoginStore _loginStore;
   List<Article> _allArticles;
   List<Article> articles;
@@ -23,7 +23,7 @@ class ArticleStore extends ChangeNotifier {
 
   Future<void> getArticles() async {
     try {
-      _allArticles = await _repository.getArticles();
+      _allArticles = await _client.getArticles();
       articles = _allArticles;
       notifyListeners();
     } on Exception catch (e) {
@@ -36,7 +36,7 @@ class ArticleStore extends ChangeNotifier {
       if (!_loginStore.isLoggedIn) {
         await _loginStore.loginAnonymously();
       }
-      await _repository.postArticle(title, before, after, body, categoryId, userID ?? '');
+      await _client.postArticle(title, before, after, body, categoryId, userID ?? '');
       notifyListeners();
     } on Exception catch (e) {
       debugPrint(e.toString());
@@ -48,7 +48,7 @@ class ArticleStore extends ChangeNotifier {
       if (userID == article.userID) {
         throw UnauthorisedException();
       }
-      await _repository.deleteArticle(article.id, userID);
+      await _client.deleteArticle(article.id, userID);
       _allArticles = _allArticles.where((element) => element.id != article.id).toList();
       articles = articles.where((element) => element.id != article.id).toList();
       notifyListeners();
@@ -62,7 +62,7 @@ class ArticleStore extends ChangeNotifier {
       if (userID == null) {
         throw UnauthorisedException();
       }
-      await _repository.likeArticle(userID, articleID);
+      await _client.likeArticle(userID, articleID);
       _allArticles.forEach(
         (article) {
           if (article.id == articleID) {
@@ -90,7 +90,7 @@ class ArticleStore extends ChangeNotifier {
       if (userID == null) {
         throw UnauthorisedException();
       }
-      await _repository.unlikeArticle(userID, articleID);
+      await _client.unlikeArticle(userID, articleID);
       _allArticles.forEach((article) {
         if (article.id == articleID) {
           article.likeUserIds.remove(userID);

--- a/lib/models/stores/category_store.dart
+++ b/lib/models/stores/category_store.dart
@@ -3,13 +3,13 @@ import 'package:gottiesclient/models/entities/entities.dart';
 import 'package:gottiesclient/models/models.dart';
 
 class CategoryStore extends ChangeNotifier {
-  CategoryStore(BaseRepository repository)
-      : assert(repository != null),
-        _repository = repository {
+  CategoryStore(BaseClient client)
+      : assert(client != null),
+        _client = client {
     getCategories();
   }
 
-  final BaseRepository _repository;
+  final BaseClient _client;
   List<Category> _categories;
   List<Category> searchedCategories;
 
@@ -18,7 +18,7 @@ class CategoryStore extends ChangeNotifier {
 
   Future<void> getCategories() async {
     try {
-      _categories = await _repository.getCategories();
+      _categories = await _client.getCategories();
       searchedCategories = _categories;
       notifyListeners();
     } on Exception catch (e) {


### PR DESCRIPTION
## やったこと
- Repositoryと命名しているところをClientに直した

ArticleStore, CategoryStore,LoginStore をRepositoryに命名変更するのは各画面にStoreを設けてから

